### PR TITLE
Add DDEV + webship-js local testing scripts for Varbase 9.2.x and 10.1.x

### DIFF
--- a/test/cmd-vdo-automated-testing-varbase9-2-x-project.sh
+++ b/test/cmd-vdo-automated-testing-varbase9-2-x-project.sh
@@ -7,9 +7,9 @@ source ${vdo_scripts}/bootstrap.sh || exit 1 ;
 eval $(parse_yaml ${vdo_config}/workspace.test.settings.yml);
 
 # Set site version.
-site_version="10.1.x-dev";
+site_version="9.2.x-dev";
 
-ARGPARSE_DESCRIPTION="Add new Varbase 10.1.x-dev ready Automated testing builds with DDEV, and install. Then run tests using webship-js (cucumber).(chromium)."
+ARGPARSE_DESCRIPTION="Add new Varbase 9.2.x-dev ready Automated testing builds with DDEV, and install. Then run tests using webship-js (cucumber).(chromium)."
 argparse "$@" <<EOF || exit 1
 parser.add_argument('PROJECT_NAME',
                     help='The name of the project.')
@@ -42,7 +42,7 @@ EOF
 shift $#;
 
 # Help link:
-# Add new Varbase 10.1 ready Automated testing builds with DDEV, install,
+# Add new Varbase 9.2 ready Automated testing builds with DDEV, install,
 # then run tests using webship-js (cucumber).
 # ---------------------------------------------------
 # https://github.com/webship/vdo-project/issues/50


### PR DESCRIPTION
Adds the local automated-testing runner scripts for Varbase **9.2.x** and **10.1.x**, mirroring the existing 11.0.x one:

- `test/cmd-vdo-automated-testing-varbase9-2-x-project.sh`
- `test/cmd-vdo-automated-testing-varbase10-1-x-project.sh`

Each builds the project with DDEV (docroot web root, PHP 8.4), installs + provisions Varbase (using the in-repo `ddev init-full-automated-testing` command when present, else an inline fallback), installs Playwright chromium, and runs the webship-js cucumber suite (`ddev yarn test:chromium`) with `--run`.

Companion to varbase_project 9.2.x MR !31 and 10.1.x MR !27 (drupal.org #3608527), which add the matching `init-full-automated-testing` DDEV command and `test:*` npm scripts.

AI-Generated: Yes (Used Claude Code; reviewed by Rajab Natshah.)